### PR TITLE
Add on zoom callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,10 @@ jitter method is set on 'method' key of the 'jitter_radius' field. Possible valu
 
 1. This is a 2d library. No fake 3d.
 2. The central zoom state is handled by d3-zoom.
-3. That zoom state can be used to render to webgl. Don't know webgl? You
-   should be able to use the zoom state to draw to canvas or svg layers using the
-   same zoom and underlying data, so that you can draw point with webgl
-   and then build a callout using d3-annotate.
+3. Use the zoom state to render other layers on top of Deepscatter by hooking in (note `on_zoom` is directly set, *not* passed in via `prefs`):
+```js
+const scatterplot = new Scatterplot('#deepscatter');
+scatterplot.on_zoom = (transform) => {...}
+```
+   
 

--- a/index.html
+++ b/index.html
@@ -106,6 +106,9 @@
   console.log(scatterplot.database)
   // Simple animation demonstration.
 
+  // In practice, you might transform an external annotations layer using this
+  scatterplot.on_zoom = (transform) => console.log('zoomed:', transform)
+
   let cycle = 0;
   select("#jitter").on("change", (event) => {
     scatterplot.plotAPI({

--- a/index.html
+++ b/index.html
@@ -49,7 +49,6 @@
     "point_size": 2, // Default point size before application of size scaling
     "background_color": "#EEEDDE",
     "click_function": "select('#ident').html(JSON.stringify(datum, undefined, 2))",
-    "on_zoom": (transform) => console.log('zoom callback with:', transform),
     "encoding": {
       "color": {
         field: "x",

--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
     "point_size": 2, // Default point size before application of size scaling
     "background_color": "#EEEDDE",
     "click_function": "select('#ident').html(JSON.stringify(datum, undefined, 2))",
+    "on_zoom": (transform) => console.log('zoom callback with:', transform),
     "encoding": {
       "color": {
         field: "x",

--- a/src/deepscatter.ts
+++ b/src/deepscatter.ts
@@ -5,7 +5,7 @@ import merge from 'lodash.merge';
 import Zoom from './interaction';
 import { ReglRenderer } from './regl_rendering';
 import { Dataset } from './Dataset';
-import type { APICall } from './types';
+import type { APICall, onZoomCallback } from './types';
 import type { StructRowProxy } from 'apache-arrow';
 import type { FeatureCollection } from 'geojson';
 import { LabelMaker } from './label_rendering';
@@ -48,6 +48,8 @@ export default class Scatterplot {
   ready: Promise<void>;
   public click_handler: ClickFunction;
   public tooltip_handler: TooltipHTML;
+  // In order to preserve JSON serializable nature of prefs, the consumer directly sets this
+  public on_zoom?: onZoomCallback;
 
   constructor(selector: string, width: number, height: number) {
     this.bound = false;

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -4,7 +4,7 @@ import { timer } from 'd3-timer';
 import { zoom, zoomIdentity } from 'd3-zoom';
 import { mean } from 'd3-array';
 import { ScaleLinear, scaleLinear } from 'd3-scale';
-import { APICall, Encoding } from './types';
+import { APICall, Encoding, onZoomCallback } from './types';
 // import { annotation, annotationLabel } from 'd3-svg-annotation';
 import type { Renderer } from './rendering';
 import type QuadtreeRoot from './tile';
@@ -28,6 +28,7 @@ export default class Zoom {
   public _scales: Record<string, d3.ScaleLinear<number, number>>;
   public zoomer: d3.ZoomBehavior<Element, any>;
   public transform: d3.ZoomTransform;
+  private _consumer_on_zoom_callback?: onZoomCallback;
   public _start: number;
   public scatterplot: Scatterplot;
   constructor(selector: string, prefs: APICall, plot: Scatterplot) {
@@ -42,6 +43,7 @@ export default class Zoom {
     this.height = +this.svg_element_selection.attr('height');
     this.renderers = new Map();
     this.scatterplot = plot;
+    this._consumer_on_zoom_callback = prefs.on_zoom;
     // A zoom keeps track of all the renderers
     // that it's in charge of adjusting.
 
@@ -139,6 +141,7 @@ export default class Zoom {
         } catch (error) {}
         this.transform = event.transform;
         this.restart_timer(10 * 1000);
+        this._consumer_on_zoom_callback?.(event.transform);
       });
 
     canvas.call(zoomer);

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -4,7 +4,7 @@ import { timer } from 'd3-timer';
 import { zoom, zoomIdentity } from 'd3-zoom';
 import { mean } from 'd3-array';
 import { ScaleLinear, scaleLinear } from 'd3-scale';
-import { APICall, Encoding, onZoomCallback } from './types';
+import { APICall, Encoding } from './types';
 // import { annotation, annotationLabel } from 'd3-svg-annotation';
 import type { Renderer } from './rendering';
 import type QuadtreeRoot from './tile';
@@ -28,7 +28,6 @@ export default class Zoom {
   public _scales: Record<string, d3.ScaleLinear<number, number>>;
   public zoomer: d3.ZoomBehavior<Element, any>;
   public transform: d3.ZoomTransform;
-  private _consumer_on_zoom_callback?: onZoomCallback;
   public _start: number;
   public scatterplot: Scatterplot;
   constructor(selector: string, prefs: APICall, plot: Scatterplot) {
@@ -43,7 +42,6 @@ export default class Zoom {
     this.height = +this.svg_element_selection.attr('height');
     this.renderers = new Map();
     this.scatterplot = plot;
-    this._consumer_on_zoom_callback = prefs.on_zoom;
     // A zoom keeps track of all the renderers
     // that it's in charge of adjusting.
 
@@ -141,7 +139,6 @@ export default class Zoom {
         } catch (error) {}
         this.transform = event.transform;
         this.restart_timer(10 * 1000);
-        this._consumer_on_zoom_callback?.(event.transform);
       });
 
     canvas.call(zoomer);

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -139,6 +139,8 @@ export default class Zoom {
         } catch (error) {}
         this.transform = event.transform;
         this.restart_timer(10 * 1000);
+        
+        this.scatterplot.on_zoom?.(event.transform)
       });
 
     canvas.call(zoomer);

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,6 +147,13 @@ type DataSpec = Record<string, never> &
     | { source_url?: never; arrow_table: Table; arrow_buffer?: never }
   );
 
+/**
+ * A callback provided by the consumer, enabling them to hook into
+ * zoom events & recieve the zoom transform. For example, a consumer
+ * might update annotations on zoom events to keep them in sync.
+ */
+export type onZoomCallback = (transform: d3.ZoomTransform) => null;
+
 export type APICall = {
   /** The magnification coefficient for a zooming item */
   zoom_balance: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,6 +147,8 @@ type DataSpec = Record<string, never> &
     | { source_url?: never; arrow_table: Table; arrow_buffer?: never }
   );
 
+export type onZoomCallback = (transform: d3.ZoomTransform) => null
+
 export type APICall = {
   /** The magnification coefficient for a zooming item */
   zoom_balance: number;
@@ -164,6 +166,8 @@ export type APICall = {
 
   /** A function defind as a string that takes implied argument 'datum' */
   click_function: string;
+
+  on_zoom: onZoomCallback;
 
   encoding: Encoding;
 } & DataSpec;

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,8 +147,6 @@ type DataSpec = Record<string, never> &
     | { source_url?: never; arrow_table: Table; arrow_buffer?: never }
   );
 
-export type onZoomCallback = (transform: d3.ZoomTransform) => null
-
 export type APICall = {
   /** The magnification coefficient for a zooming item */
   zoom_balance: number;
@@ -166,8 +164,6 @@ export type APICall = {
 
   /** A function defind as a string that takes implied argument 'datum' */
   click_function: string;
-
-  on_zoom: onZoomCallback;
 
   encoding: Encoding;
 } & DataSpec;


### PR DESCRIPTION
If a consumer wishes to add, for example, annotations, they'll need to transform those annotations when a zoom event occurs on deepscatter.

This PR introduces a way to hook into zoom events:

```js
plotAPI.on_zoom: (transform: d3.zoomTransform) => void
```

Note, this is what I originally imagined, but I don't think it's what you, @bmschmidt, had in mind. Happy to update this to fit your vision, I just wasn't as clear on what you wanted & why, so I thought I'd start here!

Your slack comment:

> https://github.com/nomic-ai/deepscatter/blob/main/src/interaction.ts#L141
> The best way to do this, I think, would be to allow registering of a zoom listener on the zoom object by assigning it to a new object that’s initialized with no members. And then on line 141 during the zoom go through the list of registered functions and call each of them with the transform as the first argument.
