### PR TITLE
Allow resizing deepscatter canvas

### DIFF
--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -43,8 +43,8 @@ export class Zoom {
     HTMLElement,
     any
   >;
-  public width: number;
-  public height: number;
+  private _width: number;
+  private _height: number;
   public renderers: Map<string, Renderer>;
   public deeptable?: Deeptable;
   public _timer?: d3.Timer;
@@ -62,8 +62,8 @@ export class Zoom {
     this.prefs = prefs;
 
     this.svg_element_selection = select(selector);
-    this.width = +this.svg_element_selection.attr('width');
-    this.height = +this.svg_element_selection.attr('height');
+    this._width = plot.width;
+    this._height = plot.height;
     this.renderers = new Map();
     this.scatterplot = plot;
     // A zoom keeps track of all the renderers
@@ -72,14 +72,40 @@ export class Zoom {
     this.renderers = new Map();
   }
 
-  attach_tiles(tiles: Deeptable) {
-    this.deeptable = tiles;
+  get width() {
+    return this._width;
+  }
+
+  get height() {
+    return this._height;
+  }
+
+  public resize(width: number, height: number) {
+    const { x_, y_ } = this.scales();
+    const old_center = [
+      x_.invert(this._width / 2),
+      y_.invert(this._height / 2),
+    ];
+    // Update the extent
+    this.zoomer.extent([
+      [0, 0],
+      [width, height],
+    ]);
+    this._width = width;
+    this._height = height;
+    this.scales(true); // Force rebuild of scales.
+    this.zoom_to(this.transform.k, old_center[0], old_center[1]);
+  }
+
+  attach_tiles(deeptable: Deeptable) {
+    this.deeptable = deeptable;
     return this;
   }
 
   attach_renderer(key: string, renderer: Renderer) {
     this.renderers.set(key, renderer);
     renderer.bind_zoom(this);
+    // Should just be `this.initialize_zoom(), right?
     renderer.zoom.initialize_zoom();
     return this;
   }
@@ -175,10 +201,10 @@ export class Zoom {
       });
 
     canvas.call(zoomer);
-
     this.add_mouseover();
 
     this.zoomer = zoomer;
+    this.resize(width, height);
   }
 
   set_highlit_points(data: StructRowProxy[]) {
@@ -292,22 +318,7 @@ export class Zoom {
     return this._timer;
   }
 
-  data(deeptable: undefined): Deeptable;
-  data(deeptable: Deeptable): Zoom;
-
-  data(deeptable: Deeptable | undefined) {
-    if (deeptable === undefined) {
-      return this.deeptable;
-    }
-    this.deeptable = deeptable;
-    return this as Zoom;
-  }
-
-  /**
-   *
-   * @returns
-   */
-  scales(): ScaleSet {
+  scales(force = false): ScaleSet {
     // General x and y scales that map from data space
     // to pixel coordinates, and also
     // rescaled ones that describe the current zoom.
@@ -316,17 +327,16 @@ export class Zoom {
 
     // equal_units: should a point of x be the same as a point of y?
 
-    if (this._scales) {
+    if (force !== true && this._scales) {
       this._scales.x_ = this.transform.rescaleX(this._scales.x);
       this._scales.y_ = this.transform.rescaleY(this._scales.y);
       return this._scales;
     }
 
     const { width, height } = this;
-    if (this.deeptable === undefined) {
-      throw new Error('Error--scales created before tileSet present.');
-    }
-    const { extent } = this.deeptable;
+
+    const extent = this.deeptable.extent;
+
     if (extent === undefined) {
       throw new Error('Error--scales created before extent present.');
     }

--- a/src/regl_rendering.ts
+++ b/src/regl_rendering.ts
@@ -470,6 +470,7 @@ export class ReglRenderer extends Renderer {
       height: this.height,
       depth: false,
     });
+
     this.fbos.ping = regl.framebuffer({
       width: this.width,
       height: this.height,
@@ -505,6 +506,20 @@ export class ReglRenderer extends Renderer {
         height: 1,
         depth: false,
       });
+  }
+
+  resize(width: number, height: number): void {
+    super.resize(width, height);
+    this.resize_textures();
+  }
+
+  resize_textures() {
+    this.fbos.colorpicker?.resize(this.width, this.height);
+    this.fbos.contour?.resize(this.width, this.height);
+    this.fbos.ping?.resize(this.width, this.height);
+    this.fbos.pong?.resize(this.width, this.height);
+    this.fbos.lines?.resize(this.width, this.height);
+    this.fbos.points?.resize(this.width, this.height);
   }
 
   get_image_texture(url: string) {

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -126,8 +126,8 @@ export class Renderer {
   public holder: d3.Selection<Element, unknown, BaseType, unknown>;
   public canvas: HTMLCanvasElement;
   public deeptable: Deeptable;
-  public width: number;
-  public height: number;
+  private _width: number;
+  private _height: number;
   public _use_scale_to_download_tiles = true;
   public aes?: AestheticSet;
   public _zoom?: Zoom;
@@ -138,9 +138,28 @@ export class Renderer {
     this.canvas = select(
       this.holder!.node()!.firstElementChild,
     ).node() as HTMLCanvasElement;
-    this.width = +select(this.canvas).attr('width');
-    this.height = +select(this.canvas).attr('height');
+    this._width = this.scatterplot.width;
+    this._height = this.scatterplot.height;
     this._use_scale_to_download_tiles = true;
+  }
+
+  get width() {
+    return this._width;
+  }
+  set width(value: number) {
+    this._width = value;
+    this.resize(this._width, this._height);
+  }
+  get height() {
+    return this._height;
+  }
+  set height(value: number) {
+    this._height = value;
+    this.resize(this._width, this._height);
+  }
+  resize(width: number, height: number) {
+    this._width = width;
+    this._height = height;
   }
 
   get discard_share() {


### PR DESCRIPTION
This PR starts implementing resizing a deepscatter plot by calling `plot.resize(width, height)`.

- [x] resize all WebGL buffers
- [x] resize all DOM elements
- [x] adjust bbox of d3.zoom
- [ ] ensure scale, get_current_corners() understand the new bbox
- [ ] maintain *center* of viewport on resize, not upper-left.
- [ ] Don't drop background color