### PR TITLE
Fixed rendering of background opacity in selection mode.

### DIFF
--- a/src/regl_rendering.ts
+++ b/src/regl_rendering.ts
@@ -892,7 +892,7 @@ export class ReglRenderer<T extends Tile> extends Renderer<T> {
             r / 255,
             g / 255,
             b / 255,
-            this.prefs.background_options.opacity,
+            this.prefs.background_options.opacity[0],
           ] as [number, number, number, number];
         },
         u_background_mouseover: () =>


### PR DESCRIPTION
In selection mode, opacity is expected to be an array with two elements specifying background and foreground opacity respectively (https://github.com/nomic-ai/deepscatter/blob/main/src/rendering.ts#L85). However, this was not reflected in the regl renderer. This PR specifies the correct (first) element for background opacity.