### PR TITLE
fix conflicting arrow dictionary bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ test-results/
 playwright-report/
 dist/tiles/*
 co2.feather co2.html
-dist/
+dist

--- a/src/utilityFunctions.ts
+++ b/src/utilityFunctions.ts
@@ -54,7 +54,6 @@ function createDictionaryWithVector(
       'values must be an array of signed integers, 32 bit or smaller.'
     );
   }
-
   const type = new Dictionary(labelsArrow.type, t, currentDictNumber++, false);
   const returnval = makeVector({
     type,


### PR DESCRIPTION
Creating an Arrow recordbatch out of multiple columns from various sources can cause conflicts in dictionary ids.
This is really an Arrow bug I think, but this is a workaround.

* Fixes NOM-250 