### PR TITLE
add-option-to-map-on-full-dataset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepscatter",
   "type": "module",
-  "version": "2.15.0-RC-1",
+  "version": "2.15.1-RC-0",
   "description": "Fast, animated zoomable scatterplots scaling to billions of points",
   "files": [
     "dist"

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,8 @@
+
+# 2.15.1
+
+* Adds a method to `Dataset` called visit_full that returns a promise which iterates over all the tiles in the dataset including those that have not yet loaded. (Their load is triggered.)
+
 # 2.15.0
 
 This would be a bugfix release except that it's possible this might accidentally break code taking advantage of undocumented behavior involving the domain for categorical scales. If you've ever set a scale to have domain [-2047, 2047], the console will now throw a warning and autochange the extent to provide more sensible support for dictionary fields. 

--- a/src/tile.ts
+++ b/src/tile.ts
@@ -74,7 +74,7 @@ export abstract class Tile {
     return this._children;
   }
 
-  download() {
+  download() : Promise<void> {
     throw new Error('Not implemented');
   }
 
@@ -253,7 +253,7 @@ export abstract class Tile {
   }
 
   async schema() {
-    this.download();
+    await this.download();
     await this.promise;
     return this._schema;
   }

--- a/vietnam2.html
+++ b/vietnam2.html
@@ -55,7 +55,7 @@
 
   const prefs = {
     source_url: 'https://bmschmidt.github.io/vietnam_war/',
-    max_points: 100000,
+    max_points: 1000,
     alpha: 10.12, // Target saturation for the full page.
     zoom_balance: 0.12, // Rate at which points increase size. https://observablehq.com/@bmschmidt/zoom-strategies-for-huge-scatterplots-with-three-js
     point_size: 2, // Default point size before application of size scaling
@@ -184,7 +184,7 @@
       scatterplot
         .plotAPI({
           alpha: 3.5,
-          max_points: 10000,
+          max_points: 1000,
           point_size: 5,
           duration: 0.1,
           encoding: {


### PR DESCRIPTION
Adds a method Dataset called `visit_full` that returns a promise which iterates over all the tiles in the dataset including those that have not yet loaded.