### PR TITLE
fix for column deletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepscatter",
   "type": "module",
-  "version": "2.15.2",
+  "version": "2.15.3",
   "description": "Fast, animated zoomable scatterplots scaling to billions of points",
   "files": [
     "dist"

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,6 @@
+# 2.15.3
+
+- properly clear the transformations cache when transformation-defined columns are deleted and then replaced with new transformations.
 
 # 2.15.1
 

--- a/src/tile.ts
+++ b/src/tile.ts
@@ -82,6 +82,10 @@ export abstract class Tile {
     if (this._batch) {
       this._buffer_manager?.release(colname);
       this._batch = add_or_delete_column(this.record_batch, colname, null);
+      if (this._batch.getChild(colname) === null) {
+        // If it was deleted, we also need to delete any promised resolutions.
+        delete this.transformation_holder[colname];
+      }
     }
   }
 


### PR DESCRIPTION
properly clear the transformations cache when transformation-defined columns are deleted and then replaced with new transformations.