### PR TITLE
Workaround batches

### DIFF
--- a/src/tile.ts
+++ b/src/tile.ts
@@ -309,6 +309,7 @@ export class Tile {
       // This helps support legacy code that may fetch the record_batch
       // just for its number of rows.
       return new RecordBatch({
+        // @ts-expect-error Arrow typing doesn't match this constructor.
         __null: vectorFromArray(Array(this.manifest.nPoints)),
       });
     }

--- a/src/tile.ts
+++ b/src/tile.ts
@@ -4,6 +4,7 @@ import {
   RecordBatch,
   StructRowProxy,
   Schema,
+  vectorFromArray,
 } from 'apache-arrow';
 import { add_or_delete_column } from './Deeptable';
 import type { Deeptable } from './Deeptable';
@@ -303,6 +304,15 @@ export class Tile {
     if (this._batch) {
       return this._batch;
     }
+
+    if (this._manifest) {
+      // This helps support legacy code that may fetch the record_batch
+      // just for its number of rows.
+      return new RecordBatch({
+        __null: vectorFromArray(Array(this.manifest.nPoints)),
+      });
+    }
+
     throw new Error(
       `Attempted to access table on tile ${this.key} without table buffer.`,
     );


### PR DESCRIPTION
Allows getting the numRows and other checks on a tile's record batch without throwing an error if the manifest is present.