### PR TITLE
fix selection mouseover

### DIFF
--- a/src/glsl/general.vert
+++ b/src/glsl/general.vert
@@ -1422,24 +1422,26 @@ void main() {
         endSize = u_background_size;
         endColor = u_background_rgba;
         endColor.a *= fill.a;
-        // endColor.rgb = vec3(0., 0., 1.);
       }
     }
 
     gl_PointSize *= mix(startSize, endSize, ease);
-    fill = mix(startColor, endColor, ease);
-
-    // Very light alphas must be quantized. Only show an appropriate sample.
-    if (fill.a < 1./255.) {
-      float seed = ix_to_random(ix, 38.6);
-      if (fill.a * 255. < seed) {
-        gl_Position = discard_me;
-        return;
-      } else {
-        fill.a = 1. / 255.;
-      }
+    if (u_color_picker_mode < 1.) {
+      fill = mix(startColor, endColor, ease);
+      // Very light alphas must be quantized. Only show an appropriate sample.
+      // Note -- this adjustment will not happen in color picking modes,
+      // which may occasionally result in one tiny point highlighted 
+      // in favor of another point in the exact same place.
+      if (fill.a < 1./255.) {
+        float seed = ix_to_random(ix, 38.6);
+        if (fill.a * 255. < seed) {
+          gl_Position = discard_me;
+          return;
+        } else {
+          fill.a = 1. / 255.;
+        }
+      }   
     }
-
   }
   point_size = gl_PointSize;
 /*  if (u_use_glyphset > 0. && point_size > 5.0) {

--- a/src/regl_rendering.ts
+++ b/src/regl_rendering.ts
@@ -803,8 +803,9 @@ export class ReglRenderer extends Renderer {
         //   }
         //   return this.textures.empty_texture;
         // },
-        //@ts-expect-error Don't know about regl preps.
-        u_color_picker_mode: regl.prop('color_picker_mode'),
+
+        u_color_picker_mode: (_: Color, { color_picker_mode }: P) =>
+          color_picker_mode,
         u_position_interpolation_mode(_, props: P) {
           // 1 indicates that there should be a continuous loop between the two points.
           if (props.position_interpolation) {


### PR DESCRIPTION
The previous PR accidentally broke selection opacity, causing mouseover to fail to find points in some circumstances, because it threw away many points with opacity < 1/255 even in mouseover mode. This fixes the problem by putting the discard logic so that it only runs with points actually being displayed on the screen.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a194126c52e84d76e9a8aeedb2a4176f8b0e3ec5  | 
|--------|--------|

### Summary:
Fixes point selection issue during mouseover by adjusting opacity discard logic in `src/glsl/general.vert` and updating `u_color_picker_mode` handling in `src/regl_rendering.ts`.

**Key points**:
- Fixes point selection issue during mouseover by adjusting opacity discard logic in `src/glsl/general.vert`.
- Discard logic now only applies when points are displayed, not during mouseover.
- Updates `u_color_picker_mode` handling in `src/regl_rendering.ts` to ensure correct behavior in color picking modes.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->