### PR TITLE
Nom 1682 webgl history

### DIFF
--- a/src/glsl/general.vert
+++ b/src/glsl/general.vert
@@ -1422,24 +1422,26 @@ void main() {
         endSize = u_background_size;
         endColor = u_background_rgba;
         endColor.a *= fill.a;
-        // endColor.rgb = vec3(0., 0., 1.);
       }
     }
 
     gl_PointSize *= mix(startSize, endSize, ease);
-    fill = mix(startColor, endColor, ease);
-
-    // Very light alphas must be quantized. Only show an appropriate sample.
-    if (fill.a < 1./255.) {
-      float seed = ix_to_random(ix, 38.6);
-      if (fill.a * 255. < seed) {
-        gl_Position = discard_me;
-        return;
-      } else {
-        fill.a = 1. / 255.;
-      }
+    if (u_color_picker_mode < 1.) {
+      fill = mix(startColor, endColor, ease);
+      // Very light alphas must be quantized. Only show an appropriate sample.
+      // Note -- this adjustment will not happen in color picking modes,
+      // which may occasionally result in one tiny point highlighted 
+      // in favor of another point in the exact same place.
+      if (fill.a < 1./255.) {
+        float seed = ix_to_random(ix, 38.6);
+        if (fill.a * 255. < seed) {
+          gl_Position = discard_me;
+          return;
+        } else {
+          fill.a = 1. / 255.;
+        }
+      }   
     }
-
   }
   point_size = gl_PointSize;
 /*  if (u_use_glyphset > 0. && point_size > 5.0) {

--- a/src/regl_rendering.ts
+++ b/src/regl_rendering.ts
@@ -803,8 +803,9 @@ export class ReglRenderer extends Renderer {
         //   }
         //   return this.textures.empty_texture;
         // },
-        //@ts-expect-error Don't know about regl preps.
-        u_color_picker_mode: regl.prop('color_picker_mode'),
+
+        u_color_picker_mode: (_: Color, { color_picker_mode }: P) =>
+          color_picker_mode,
         u_position_interpolation_mode(_, props: P) {
           // 1 indicates that there should be a continuous loop between the two points.
           if (props.position_interpolation) {


### PR DESCRIPTION
There is an occasional error condition where some network transactions need to resolve before we can do our first render call (so that we know what the bounding box of the data is.) This manifests as errors that throw `this._webgl_scale_history is undefined`. Here we prevent the animation frame from dispatching draw calls before they are ready. 
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d32797c4df05c43212c0b8f9ae24927fcb045b1f  | 
|--------|--------|

### Summary:
This PR prevents rendering errors by ensuring WebGL scale history is initialized before rendering and adjusts color handling in `src/glsl/general.vert`.

**Key points**:
- Prevents rendering before WebGL scale history is initialized in `src/regl_rendering.ts`.
- Checks `this._webgl_scale_history` in `ReglRenderer.tick` to avoid undefined errors.
- Adjusts `src/glsl/general.vert` to handle color picking modes and alpha quantization.
- Ensures `u_color_picker_mode` is less than 1 before adjusting alpha in `general.vert`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->