### PR TITLE
Remove the deferred functions queue

### DIFF
--- a/src/regl_rendering.ts
+++ b/src/regl_rendering.ts
@@ -228,8 +228,6 @@ export class ReglRenderer extends Renderer {
         tile._buffer_manager || new TileBufferManager(this.regl, tile, this);
 
       if (!tile._buffer_manager.ready()) {
-        // The 'ready' call also pushes a creation request into
-        // the deferred_functions queue.
         continue;
       }
       const this_props = {
@@ -295,25 +293,6 @@ export class ReglRenderer extends Renderer {
     }
 
     const start = Date.now();
-
-    async function pop_deferred_functions(
-      deferred_functions: (() => void | Promise<void>)[],
-    ) {
-      while (Date.now() - start < 10 && deferred_functions.length > 0) {
-        // Keep popping deferred functions off the queue until we've spent 10 milliseconds doing it.
-        const current = deferred_functions.shift();
-        if (current === undefined) {
-          continue;
-        }
-        try {
-          await current();
-        } catch (error) {
-          console.warn(error, current);
-        }
-      }
-    }
-    // Run 10 ms of deferred functions.
-    void pop_deferred_functions(this.deferred_functions);
 
     try {
       this.render_all(props);

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -128,8 +128,6 @@ export class Renderer {
   public deeptable: Deeptable;
   public width: number;
   public height: number;
-  // The renderer handles periodic dispatches of calls
-  public deferred_functions: Array<() => Promise<void> | void>;
   public _use_scale_to_download_tiles = true;
   public aes?: AestheticSet;
   public _zoom?: Zoom;
@@ -142,7 +140,6 @@ export class Renderer {
     ).node() as HTMLCanvasElement;
     this.width = +select(this.canvas).attr('width');
     this.height = +select(this.canvas).attr('height');
-    this.deferred_functions = [];
     this._use_scale_to_download_tiles = true;
   }
 


### PR DESCRIPTION
This is dead code, and is a pretty finicky thing that we could implement better.
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by 6a2a804aa5d1677fea66e5b2363484af78aecc89  | 
|--------|--------|

refactor: remove unused deferred functions from rendering classes

### Summary:
This pull request removes unused deferred functions from rendering classes to simplify the rendering process.

**Key points**:
- Remove unused `deferred_functions` array from `Renderer` class in `src/rendering.ts`.
- Remove `pop_deferred_functions` function from `ReglRenderer` class in `src/regl_rendering.ts`.
- Delete comments related to deferred functions in both files.
- Simplify rendering process by removing unused code.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->