### PR TITLE
add tuple map class

### DIFF
--- a/src/utilityFunctions.ts
+++ b/src/utilityFunctions.ts
@@ -82,3 +82,69 @@ function createDictionaryWithVector(
 
   return returnval;
 }
+
+export class TupleMap<K = Object, V = Object> {
+  private map: Map<K, TupleMap<K, V>> = new Map();
+  private value?: V;
+
+  set(keys: K[], value: V): void {
+    let currentMap: TupleMap<K, V> = this;
+    for (const key of keys) {
+      if (!currentMap.map.has(key)) {
+        currentMap.map.set(key, new TupleMap<K, V>());
+      }
+      currentMap = currentMap.map.get(key);
+    }
+    currentMap.value = value;
+  }
+
+  get(keys: K[]): V | undefined {
+    let currentMap: TupleMap<K, V> = this;
+    for (const key of keys) {
+      currentMap = currentMap.map.get(key) as TupleMap<K, V>;
+      if (!currentMap) {
+        return undefined;
+      }
+    }
+    return currentMap.value;
+  }
+
+  has(keys: K[]): boolean {
+    let currentMap: TupleMap<K, V> = this;
+    for (const key of keys) {
+      currentMap = currentMap.map.get(key) as TupleMap<K, V>;
+      if (!currentMap) {
+        return false;
+      }
+    }
+    return currentMap.value !== undefined;
+  }
+
+  delete(keys: K[]): boolean {
+    let currentMap: TupleMap<K, V> = this;
+    const stack: TupleMap<K, V>[] = [];
+
+    for (const key of keys) {
+      if (!currentMap.map.has(key)) {
+        return false;
+      }
+      stack.push(currentMap);
+      currentMap = currentMap.map.get(key) as TupleMap<K, V>;
+    }
+
+    currentMap.value = undefined;
+
+    // Clean up empty nested maps
+    for (let i = keys.length - 1; i >= 0; i--) {
+      const parentMap = stack[i];
+      const key = keys[i];
+      const childMap = parentMap.map.get(key) as TupleMap<K, V>;
+
+      // Remove map if it has no value and no nested maps
+      if (!childMap.value && childMap.map.size === 0) {
+        parentMap.map.delete(key);
+      }
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
We often have to use a tuple of things as indexes in deepscatter. This creates a class that allows accessing things by string (or object) indexes so that you can do things like:

```js
const a = new TupleMap();
a.set(["foo", "bar"], 2)
a.get(["foo", "bar"])
// == 3
```

Even though the objects don't match.
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by 48c5da6c314f19ec9c2c8c9dc7d03fc022534f5b  | 
|--------|--------|

feat: add `TupleMap` class for tuple-based indexing

### Summary:
Introduces `TupleMap` class for efficient tuple-based indexing with string or object keys, supporting various methods and cleaning up empty maps.

**Key points**:
- Introduces `TupleMap` class in `src/utilityFunctions.ts` for tuple-based indexing.
- Supports `set`, `get`, `has`, and `delete` methods.
- Allows string or object keys in tuples.
- Handles non-matching object keys gracefully.
- Cleans up empty nested maps after deletion.
- Example usage: `a.set(["foo", "bar"], 2); a.get(["foo", "bar"])`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->