### PR TITLE
bump arrow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "vite": "^5.4.3"
       },
       "peerDependencies": {
-        "apache-arrow": ">=11.0.0 <17.0.0"
+        "apache-arrow": "^17.0.0"
       }
     },
     "node_modules/@75lb/deep-merge": {
@@ -1001,9 +1001,9 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.6.tgz",
-      "integrity": "sha512-aYX01Ke9hunpoCexYAgQucEpARGQ5w/cqHFrIR+e9gdKb1QWTsVJuTJ2ozQzIAxLyRQe/m+2RqzkyOOGiMKRQA==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.13.tgz",
+      "integrity": "sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -1016,8 +1016,9 @@
       "peer": true
     },
     "node_modules/@types/command-line-usage": {
-      "version": "5.0.2",
-      "license": "MIT",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
       "peer": true
     },
     "node_modules/@types/d3": {
@@ -1294,11 +1295,11 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.11.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.20.tgz",
-      "integrity": "sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==",
+      "version": "20.16.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.5.tgz",
+      "integrity": "sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -1603,18 +1604,18 @@
       }
     },
     "node_modules/apache-arrow": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-15.0.2.tgz",
-      "integrity": "sha512-RvwlFxLRpO405PLGffx4N2PYLiF7FD86Q1hHl6J2XCWiq+tTCzpb9ngFw0apFDcXZBMpCzMuwAvA7hjyL1/73A==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-17.0.0.tgz",
+      "integrity": "sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==",
       "peer": true,
       "dependencies": {
-        "@swc/helpers": "^0.5.2",
-        "@types/command-line-args": "^5.2.1",
-        "@types/command-line-usage": "^5.0.2",
-        "@types/node": "^20.6.0",
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^20.13.0",
         "command-line-args": "^5.2.1",
         "command-line-usage": "^7.0.1",
-        "flatbuffers": "^23.5.26",
+        "flatbuffers": "^24.3.25",
         "json-bignum": "^0.0.3",
         "tslib": "^2.6.2"
       },
@@ -3539,9 +3540,9 @@
       }
     },
     "node_modules/flatbuffers": {
-      "version": "23.5.26",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-23.5.26.tgz",
-      "integrity": "sha512-vE+SI9vrJDwi1oETtTIFldC/o9GsVKRM+s6EL0nQgxXlYV1Vc4Tk30hj4xGICftInKQKj1F3up2n8UbIVobISQ==",
+      "version": "24.3.25",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.3.25.tgz",
+      "integrity": "sha512-3HDgPbgiwWMI9zVB7VYBHaMrbOO7Gm0v+yD2FV/sCKj+9NDeVL7BOBYUuhWAQGKWOzBo8S9WdMvV0eixO233XQ==",
       "peer": true
     },
     "node_modules/flatted": {
@@ -6564,9 +6565,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.0",
@@ -7387,9 +7388,9 @@
       }
     },
     "@swc/helpers": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.6.tgz",
-      "integrity": "sha512-aYX01Ke9hunpoCexYAgQucEpARGQ5w/cqHFrIR+e9gdKb1QWTsVJuTJ2ozQzIAxLyRQe/m+2RqzkyOOGiMKRQA==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.13.tgz",
+      "integrity": "sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==",
       "peer": true,
       "requires": {
         "tslib": "^2.4.0"
@@ -7402,7 +7403,9 @@
       "peer": true
     },
     "@types/command-line-usage": {
-      "version": "5.0.2",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
       "peer": true
     },
     "@types/d3": {
@@ -7651,11 +7654,11 @@
       }
     },
     "@types/node": {
-      "version": "20.11.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.20.tgz",
-      "integrity": "sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==",
+      "version": "20.16.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.5.tgz",
+      "integrity": "sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==",
       "requires": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.19.2"
       }
     },
     "@types/normalize-package-data": {
@@ -7846,18 +7849,18 @@
       }
     },
     "apache-arrow": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-15.0.2.tgz",
-      "integrity": "sha512-RvwlFxLRpO405PLGffx4N2PYLiF7FD86Q1hHl6J2XCWiq+tTCzpb9ngFw0apFDcXZBMpCzMuwAvA7hjyL1/73A==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-17.0.0.tgz",
+      "integrity": "sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==",
       "peer": true,
       "requires": {
-        "@swc/helpers": "^0.5.2",
-        "@types/command-line-args": "^5.2.1",
-        "@types/command-line-usage": "^5.0.2",
-        "@types/node": "^20.6.0",
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^20.13.0",
         "command-line-args": "^5.2.1",
         "command-line-usage": "^7.0.1",
-        "flatbuffers": "^23.5.26",
+        "flatbuffers": "^24.3.25",
         "json-bignum": "^0.0.3",
         "tslib": "^2.6.2"
       }
@@ -9198,9 +9201,9 @@
       }
     },
     "flatbuffers": {
-      "version": "23.5.26",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-23.5.26.tgz",
-      "integrity": "sha512-vE+SI9vrJDwi1oETtTIFldC/o9GsVKRM+s6EL0nQgxXlYV1Vc4Tk30hj4xGICftInKQKj1F3up2n8UbIVobISQ==",
+      "version": "24.3.25",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.3.25.tgz",
+      "integrity": "sha512-3HDgPbgiwWMI9zVB7VYBHaMrbOO7Gm0v+yD2FV/sCKj+9NDeVL7BOBYUuhWAQGKWOzBo8S9WdMvV0eixO233XQ==",
       "peer": true
     },
     "flatted": {
@@ -11370,9 +11373,9 @@
       }
     },
     "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "update-browserslist-db": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/nomic-ai/deepscatter#readme",
   "peerDependencies": {
-    "apache-arrow": ">=11.0.0 <17.0.0"
+    "apache-arrow": ">=11.0.0"
   },
   "dependencies": {
     "d3-array": "^3.2.4",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ab53736ebd65497c6b240d50b27a619d0eac7eb5  | 
|--------|--------|

chore: bump `apache-arrow` peer dependency version

### Summary:
Bump `apache-arrow` peer dependency to `^17.0.0`, noting new commit's `>=11.0.0`.

**Key points**:
- **Dependencies**:
  - Bump `apache-arrow` peer dependency version in `package.json` from `>=11.0.0 <17.0.0` to `^17.0.0`.
  - Note: New commit suggests `>=11.0.0`, but `^17.0.0` is prioritized.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->