### PR TITLE
chore: github workflow publication action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,7 +2,7 @@ name: Publish @next release to npm
 on:
   push:
     branches:
-      - dev
+      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
`main` is the primary branch now; formal npm releases will be handled through a release process, and every merge to main to will trigger a pre-release as previously happened on `dev`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change branch trigger in GitHub workflow from `dev` to `main` for npm pre-releases.
> 
>   - **GitHub Workflow**:
>     - Change branch trigger in `.github/workflows/npm-publish.yml` from `dev` to `main` for npm pre-releases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai/deepscatter#147)<sup> for 738ed1374693bcfc3eded8183de6c9e10ff9c22e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->