### PR TITLE
fix typing on arrow table imports

### DIFF
--- a/src/Deeptable.ts
+++ b/src/Deeptable.ts
@@ -290,14 +290,19 @@ export class Deeptable {
   }
 
   /**
-   * Generate an ArrowDeeptable from a single Arrow table.
+   * Generate a deeptable from a single Arrow table.
    *
    * @param table A single Arrow table
    * @param prefs The API Call to use for rendering.
-   * @param plot The Scatterplot to use.
+   * @param plot Optionally: the scatterplot to bind the deeptable to.
+   * If null, the deeptable can be used independently (including in node environments),
+   * or bound to a scatterplot later.
    * @returns
    */
-  static fromArrowTable(table: Table, plot: Scatterplot): Deeptable {
+  static fromArrowTable(
+    table: Table,
+    plot: Scatterplot | null = null,
+  ): Deeptable {
     return wrapArrowTable(tableToIPC(table), plot);
   }
 

--- a/src/wrap_arrow.ts
+++ b/src/wrap_arrow.ts
@@ -15,10 +15,16 @@ import type * as DS from './types';
 import { extent } from 'd3-array';
 import { Rectangle } from './tile';
 
-// This function is used to wrap an arrow table into a
-// deeptable so that record batches can be fetched asynchronously.
-// The point display order is the same as in the original file.
-// It is exposed primarily as Deeptable.from
+/**
+ * This function is used to wrap an arrow table into a
+ * deeptable so that record batches can be fetched asynchronously.
+ * The point display order is the same as in the original file.
+ * It is exposed primarily as Deeptable.fromArrowTable
+ * @param tbArray a Uint8 Array that deserializes to an Arrow table. incompatibility between Arrow
+ * versions makes it easier to simple force this transformation.
+ * @param plot Optionally, a Scatterplot.
+ * @returns
+ */
 export function wrapArrowTable(
   tbArray: Uint8Array,
   plot: Scatterplot | null,


### PR DESCRIPTION
It is possible to instantiate a deeptable from an arrow table without an associated scatterplot, but the types didn't reflect that.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `fromArrowTable` and `wrapArrowTable` to support `null` `Scatterplot`, allowing `Deeptable` instantiation without a scatterplot.
> 
>   - **Behavior**:
>     - `fromArrowTable` in `Deeptable.ts` now accepts `Scatterplot | null` for `plot` parameter, allowing `Deeptable` instantiation without a scatterplot.
>     - `wrapArrowTable` in `wrap_arrow.ts` updated to handle `null` `Scatterplot` parameter.
>   - **Documentation**:
>     - Updated docstrings in `Deeptable.ts` and `wrap_arrow.ts` to reflect optional `plot` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fdeepscatter&utm_source=github&utm_medium=referral)<sup> for 2f74881937750cd458adba558f8faca5e09e34aa. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->