### PR TITLE
clean transitions between struct-nested fields

### DIFF
--- a/dev/svelte/SwitchPositions.svelte
+++ b/dev/svelte/SwitchPositions.svelte
@@ -13,75 +13,61 @@
 
   let positionNum = 0;
   async function click() {
-    for (let i = 0; i < 10; i++) {
-      if (scatterplot.deeptable.transformations['struct' + i]) {
-        continue;
-      }
-      scatterplot.deeptable.transformations['struct' + i] = async function (
-        tile,
-      ) {
-        // Create a nested struct with a change.
-        const x = (await tile.get_column('x')).toArray();
-        const y = (await tile.get_column('y')).toArray();
+    if (scatterplot.deeptable.transformations['struct'] === undefined) {
+      scatterplot.deeptable.transformations['struct'] = async function (tile) {
+        const fields = [];
+        const vectors = [];
+        for (let h = 0; h < 10; h++) {
+          // Create a nested struct with a change.
+          const x = (await tile.get_column('x')).toArray();
+          const y = (await tile.get_column('y')).toArray();
 
-        const x_ = new Float32Array(x.length);
-        const y_ = new Float32Array(y.length);
+          const x_ = new Float32Array(x.length);
+          const y_ = new Float32Array(y.length);
 
-        for (let i = 0; i < x.length; i++) {
-          const r = (Math.random() + Math.random()) / 3;
-          const theta = Math.random() * Math.PI * 2;
-          x_[i] = x[i] + Math.cos(theta) * r;
-          y_[i] = y[i] + Math.sin(theta) * r;
+          for (let i = 0; i < x.length; i++) {
+            const r = (Math.random() + Math.random()) / 3;
+            const theta = Math.random() * Math.PI * 2;
+            x_[i] = x[i] + Math.cos(theta) * r;
+            y_[i] = y[i] + Math.sin(theta) * r;
+          }
+          fields.push(new Field(`x${h}`, new Float32()));
+          vectors.push(vectorFromArray(x_).data[0]);
+          fields.push(new Field(`y${h}`, new Float32()));
+          vectors.push(vectorFromArray(y_).data[0]);
         }
 
         const d = makeData({
-          type: new Struct([
-            new Field('x', new Float32()),
-            new Field('y', new Float32()),
-          ]),
-          children: [vectorFromArray(x_).data[0], vectorFromArray(y_).data[0]],
+          type: new Struct(fields),
+          children: vectors,
         });
         const r = new Vector([d]);
         return r;
       };
 
-      scatterplot.deeptable.map((d) => d.get_column('struct' + i));
+      scatterplot.deeptable.map((d) => d.get_column('struct'));
+      // await new Promise<void>((resolve) => {
+      //   setTimeout(() => resolve(), 100);
+      // });
     }
-    await new Promise((resolve) => {
-      setTimeout(() => resolve());
-    }, 100);
-    let r = 'struct' + (positionNum++ % 10);
+    positionNum = (positionNum + 1) % 10;
     await scatterplot.plotAPI({
       duration: 1000,
       encoding: {
         x: {
-          field: r,
-          subfield: ['x'],
+          field: 'struct',
+          subfield: [`x${positionNum}`],
           transform: 'literal',
           domain: [-10, 10],
         },
         y: {
-          field: r,
-          subfield: ['y'],
+          field: 'struct',
+          subfield: [`y${positionNum}`],
           transform: 'literal',
           domain: [-10, 10],
         },
       },
     });
-    // await scatterplot.plotAPI({
-    //   encoding: {
-    //     x: {
-    //       field: scatterplot.prefs.encoding.x.field === 'x' ? 'y' : 'x',
-    //       transform:
-    //         scatterplot.prefs.encoding.x.field === 'x' ? 'linear' : 'literal',
-    //     },
-    //     y: {
-    //       field: scatterplot.prefs.encoding.y.field === 'y' ? 'x' : 'y',
-    //       transform:
-    //         scatterplot.prefs.encoding.y.field === 'y' ? 'linear' : 'literal',
-    //     },
-    //   },
-    // });
   }
 </script>
 

--- a/src/Deeptable.ts
+++ b/src/Deeptable.ts
@@ -366,7 +366,6 @@ export class Deeptable {
       if (dim === undefined) {
         continue;
       }
-      console.log({ dim });
       dim = (dim as Field<Struct<any>>).type.children.find(
         (d) => d.name === sub,
       );

--- a/src/aesthetics/AestheticSet.ts
+++ b/src/aesthetics/AestheticSet.ts
@@ -55,7 +55,7 @@ export class AestheticSet {
     // Used for things like 'what color would this point be?'
 
     if (this.store[aesthetic]) {
-      const v = this.store[aesthetic]
+      const v = this.store[aesthetic];
       return v;
     }
     if (!dimensions[aesthetic]) {
@@ -84,7 +84,7 @@ export class AestheticSet {
     }
   }
 
-  _neededFields: TupleSet<string> = new TupleSet();
+  _neededFields: TupleSet<string> = new TupleSet<string>();
 
   get neededFields(): string[][] {
     return [...this._neededFields.values()];
@@ -117,6 +117,8 @@ export class AestheticSet {
     // Update the needed fields.
     this._neededFields.clear();
 
+    // We always need the 'ix' column
+    this._neededFields.add(['ix']);
     for (const v of Object.values(this.store)) {
       if (v instanceof StatefulAesthetic) {
         for (const f of v.neededFields) {

--- a/src/regl_rendering.ts
+++ b/src/regl_rendering.ts
@@ -956,7 +956,6 @@ export class ReglRenderer extends Renderer {
         variable_to_buffer_num.set(field, num);
         continue;
       } else {
-        console.log('Overflow');
         // Don't use the last value, use the current value.
         // Loses animation but otherwise plots nicely.
         // Strategy will break if more than 14 base channels are defined,

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -477,8 +477,6 @@ export class DataSelection {
         params.ids,
         params.idField,
       ).then(markReady);
-      // } else if (isBooleanColumnParam(params)) {
-      //   void this.add_boolean_column(params.name, params.field).then(markReady);
     } else if (isFunctionSelectParam(params)) {
       void this.add_function_column(params.name, params.tileFunction).then(
         markReady,

--- a/src/types.ts
+++ b/src/types.ts
@@ -637,7 +637,7 @@ export type GlobalDrawProps = {
   use_scale_for_tiles: boolean;
   grid_mode: 1 | 0;
   buffer_num_to_variable: string[][];
-  aes_to_buffer_num: Record<string, number>;
+  aes_to_buffer_num: TupleMap<string, number>;
   variable_to_buffer_num: TupleMap<string, number>;
   color_picker_mode: 0 | 1 | 2 | 3;
   zoom_matrix: [

--- a/src/utilityFunctions.ts
+++ b/src/utilityFunctions.ts
@@ -97,7 +97,7 @@ export type Some<T> = [T, ...T[]];
 /**
  * A Map that allows for tuples as keys with proper identity checks.
  */
-export class TupleMap<K = Object, V = Object> {
+export class TupleMap<K = object, V = object> {
   private map: Map<K, TupleMap<K, V>> = new Map();
   private value?: V;
 


### PR DESCRIPTION
There was a bug caused by a failure to properly sort values in the list of buffers. When delving into struct array fields, an additional sort operation is necessary.

This fixes that, and also includes a number of type improvements that I made while hunting down that bug. 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes sorting issue in `SwitchPositions.svelte` for struct fields and improves type safety with `TupleMap` across the codebase.
> 
>   - **Behavior**:
>     - Fixes sorting issue in `SwitchPositions.svelte` by ensuring nested struct fields are handled correctly.
>     - Updates `click()` function to handle struct fields with dynamic subfields.
>   - **Type Improvements**:
>     - Replaces `Record<string, number>` with `TupleMap<string, number>` in `Deeptable.ts`, `AestheticSet.ts`, and `regl_rendering.ts` for better type safety.
>     - Updates `TupleMap` and `TupleSet` usage in `utilityFunctions.ts`.
>   - **Misc**:
>     - Removes unused code and comments in `SwitchPositions.svelte` and `selection.ts`.
>     - Minor logging and code cleanup in `regl_rendering.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fdeepscatter&utm_source=github&utm_medium=referral)<sup> for 5e2f32a0eb04cd14336f8580cc5c11e3403d10b7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->