### PR TITLE
fix xy coords on tooltips

### DIFF
--- a/src/aesthetics/ScaledAesthetic.ts
+++ b/src/aesthetics/ScaledAesthetic.ts
@@ -146,7 +146,10 @@ export abstract class ScaledAesthetic<
     if (this.field === null || isConstantChannel(this.encoding)) {
       return constant as Output['rangeType'];
     }
-    const value = point[this.field] as Input['domainType'];
+    let value = point[this.field] as Input['domainType'];
+    for (const subfield of this.subfield) {
+      value = value[subfield] as Input['domainType'];
+    }
     if (value === undefined || value === null) {
       return constant as Output['rangeType'];
     }

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -96,8 +96,8 @@ export class Zoom {
   }
 
   html_annotation(points: Annotation[]) {
-    const div = this.svg_element_selection.node()!.parentNode
-      .parentNode as unknown as string;
+    const div = this.svg_element_selection.node().parentNode
+      .parentNode as HTMLDivElement;
     const els = select(div)
       .selectAll('div.tooltip')
       .data(points)

--- a/src/regl_rendering.ts
+++ b/src/regl_rendering.ts
@@ -956,6 +956,7 @@ export class ReglRenderer extends Renderer {
         variable_to_buffer_num.set(field, num);
         continue;
       } else {
+        console.log('Overflow');
         // Don't use the last value, use the current value.
         // Loses animation but otherwise plots nicely.
         // Strategy will break if more than 14 base channels are defined,


### PR DESCRIPTION
The svg tooltip circles weren't displaying the correct coordinates when x or y was a struct. This fixes the 'apply' function so that it descends struts.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes tooltip coordinate issue in `ScaledAesthetic.ts` and corrects type in `interaction.ts`.
> 
>   - **Behavior**:
>     - Fixes tooltip coordinate issue in `apply()` of `ScaledAesthetic` class in `ScaledAesthetic.ts` by correctly handling struct subfields.
>   - **Type Corrections**:
>     - Corrects type casting in `html_annotation()` in `interaction.ts` from `string` to `HTMLDivElement`.
>   - **Misc**:
>     - Adds a console log for buffer overflow in `regl_rendering.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fdeepscatter&utm_source=github&utm_medium=referral)<sup> for 08f897db6b23e5c9a500cb820abcda03ac736b57. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->