### PR TITLE
[RFR] Heap Sort on Tiles

### DIFF
--- a/src/Deeptable.ts
+++ b/src/Deeptable.ts
@@ -175,6 +175,10 @@ export class Deeptable {
     });
   }
 
+  get tiles(): Tile[] {
+    return this.map(d => d);
+  }
+
   get plot() {
     if (this._plot === undefined) {
       throw new Error('Plot not yet bound');

--- a/src/Deeptable.ts
+++ b/src/Deeptable.ts
@@ -175,10 +175,6 @@ export class Deeptable {
     });
   }
 
-  get tiles(): Tile[] {
-    return this.map(d => d);
-  }
-
   get plot() {
     if (this._plot === undefined) {
       throw new Error('Plot not yet bound');

--- a/src/deepscatter.ts
+++ b/src/deepscatter.ts
@@ -25,5 +25,5 @@ export type {
   OpChannel,
   TileProxy,
   DeeptableCreateParams,
-  Transformation,
+  Transformation
 } from './types';

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1235,8 +1235,8 @@ export class TileSorter
 
     // Finally add to heap
     for (const sortInfo of sortInfos) {
-      // Only add if we haven't reached the end of the values
-      if (sortInfo.pointer < sortInfo.values.length) {
+      // Only add if there are indices and we haven't reached the end of the values
+      if (sortInfo.indices.length > 0 && sortInfo.pointer < sortInfo.values.length) {
         this.valueHeap.insert(sortInfo);
       }
     }
@@ -1255,7 +1255,10 @@ export class TileSorter
     } else {
       for (const tile of this.tiles) {
         const rawSortInfo = tile.sorts[this.sortKey];
-
+        // Skip tiles with empty selections
+        if (rawSortInfo.indices.length <= 0) {
+          continue
+        }
         const sortInfo: SortInfoWithPointer = {
           ...rawSortInfo,
           pointer:
@@ -1318,7 +1321,7 @@ function quickSelect(
   );
 
   if (k < 0 || k >= size) {
-    console.error('Index out of bounds');
+    throw new Error('Index out of bounds');
     return undefined;
   }
 

--- a/src/utilityFunctions.ts
+++ b/src/utilityFunctions.ts
@@ -192,7 +192,7 @@ export class TupleMap<K = object, V = object> {
   }
 }
 
-export class TupleSet<K = Object> {
+export class TupleSet<K = object> {
   private map = new TupleMap<K, boolean>();
 
   constructor(v: Some<K>[] = []) {
@@ -232,7 +232,6 @@ export class TupleSet<K = Object> {
     this.map = new TupleMap();
   }
 }
-
 
 export class MinHeap<T> {
   private heap: T[] = [];
@@ -315,7 +314,8 @@ export class MinHeap<T> {
         const rightChild = this.heap[rightChildIndex];
         if (
           (swapIndex === null && this.comparator(rightChild, element) < 0) ||
-          (swapIndex !== null && this.comparator(rightChild, this.heap[swapIndex]) < 0)
+          (swapIndex !== null &&
+            this.comparator(rightChild, this.heap[swapIndex]) < 0)
         ) {
           swapIndex = rightChildIndex;
         }

--- a/src/utilityFunctions.ts
+++ b/src/utilityFunctions.ts
@@ -232,3 +232,100 @@ export class TupleSet<K = Object> {
     this.map = new TupleMap();
   }
 }
+
+
+export class MinHeap<T> {
+  private heap: T[] = [];
+  private comparator: (a: T, b: T) => number;
+
+  constructor(comparator: (a: T, b: T) => number) {
+    this.comparator = comparator;
+  }
+
+  /** Inserts a new element into the heap */
+  public insert(value: T): void {
+    this.heap.push(value);
+    this.bubbleUp();
+  }
+
+  /** Extracts and returns the minimum element from the heap */
+  public extractMin(): T | undefined {
+    if (this.heap.length === 0) return undefined;
+
+    const min = this.heap[0];
+    const end = this.heap.pop();
+
+    if (this.heap.length > 0 && end !== undefined) {
+      this.heap[0] = end;
+      this.bubbleDown();
+    }
+
+    return min;
+  }
+
+  /** Returns true if the heap is empty */
+  public isEmpty(): boolean {
+    return this.heap.length === 0;
+  }
+
+  /** Returns the size of the heap */
+  public size(): number {
+    return this.heap.length;
+  }
+
+  /** Returns the minimum element without removing it */
+  public peek(): T | undefined {
+    return this.heap[0];
+  }
+
+  private bubbleUp(): void {
+    let index = this.heap.length - 1;
+    const element = this.heap[index];
+
+    while (index > 0) {
+      const parentIndex = Math.floor((index - 1) / 2);
+      const parent = this.heap[parentIndex];
+
+      if (this.comparator(element, parent) >= 0) break;
+
+      this.heap[index] = parent;
+      this.heap[parentIndex] = element;
+      index = parentIndex;
+    }
+  }
+
+  private bubbleDown(): void {
+    let index = 0;
+    const length = this.heap.length;
+    const element = this.heap[0];
+
+    while (true) {
+      let swapIndex: number | null = null;
+      const leftChildIndex = 2 * index + 1;
+      const rightChildIndex = 2 * index + 2;
+
+      if (leftChildIndex < length) {
+        const leftChild = this.heap[leftChildIndex];
+        if (this.comparator(leftChild, element) < 0) {
+          swapIndex = leftChildIndex;
+        }
+      }
+
+      if (rightChildIndex < length) {
+        const rightChild = this.heap[rightChildIndex];
+        if (
+          (swapIndex === null && this.comparator(rightChild, element) < 0) ||
+          (swapIndex !== null && this.comparator(rightChild, this.heap[swapIndex]) < 0)
+        ) {
+          swapIndex = rightChildIndex;
+        }
+      }
+
+      if (swapIndex === null) break;
+
+      this.heap[index] = this.heap[swapIndex];
+      this.heap[swapIndex] = element;
+      index = swapIndex;
+    }
+  }
+}

--- a/tests/dataset.spec.js
+++ b/tests/dataset.spec.js
@@ -122,7 +122,6 @@ test('Test sorting of selections', async () => {
   assert.ok(mid.random < 0.55);
 });
 
-
 test('Test iterated sorting of selections', async () => {
   const dataset = createIntegerDataset();
   await dataset.root_tile.preprocessRootTileInfo();
@@ -130,7 +129,7 @@ test('Test iterated sorting of selections', async () => {
     name: 'twos2',
     tileFunction: selectFunctionForFactorsOf(2),
   });
-  const sortKey = 'random'
+  const sortKey = 'random';
   await selectEvens.applyToAllTiles();
   const sorted = await SortedDataSelection.fromSelection(
     selectEvens,
@@ -139,25 +138,37 @@ test('Test iterated sorting of selections', async () => {
   );
   await sorted.applyToAllTiles();
 
+  let size = 0;
   // Go nomral direction
   let prevValue = Number.NEGATIVE_INFINITY;
-  for await (const row of sorted.iterator()) {
+  for (const row of sorted.iterator()) {
+    size++;
+    // This test needs to handle that it's a structRowProxy now not a value.
     const currValue = row[sortKey];
-    assert.ok(currValue >= prevValue)
+    assert.ok(currValue >= prevValue);
     prevValue = currValue;
   }
 
-  prevValue = Number.POSITIVE_INFINITY;
-  let count = 0;
-  // Go reverse direction with a start
-  for await (const row of sorted.iterator(5, true)) {
-    const currValue = row[sortKey];
-    assert.ok(currValue <= prevValue);
-    prevValue = currValue;
-    count ++;
-  }
+  assert.ok(size, sorted.selectionSize);
   // Since flipped direction, your start is how many elements you will iterate
-  assert.ok(count, 5);
+
+  const first = sorted.iterator(0);
+  const second = sorted.iterator(10);
+
+  let sizeFirst = 20;
+  const elementsFirst = [];
+  for (const row of sorted.iterator()) {
+    sizeFirst--;
+    if (sizeFirst === 0) {
+      break;
+    }
+    elementsFirst.push(row[sortKey]);
+  }
+
+  // Something to test that the second iterator doesn't end up with state elements
+  // from the first and that it starts from the 10th item in the first.
+
+  // Since flipped direction, your start is how many elements you will iterate
 });
 
 test.run();

--- a/tests/datasetHelpers.js
+++ b/tests/datasetHelpers.js
@@ -15,6 +15,19 @@ export function selectFunctionForFactorsOf(n) {
   };
 }
 
+// Creates a tile transformation that just takes random rows
+export function selectRandomRows(p = 0.5) {
+  return async(tile) => {
+    const mask = new Bitmask(tile.record_batch.numRows);
+    for (let i = 0; i < tile.record_batch.numRows; i++) {
+      if (Math.random() < p) {
+        mask.set(i);
+      }
+    }
+    return mask.to_arrow();
+  }
+}
+
 function make_batch(start = 0, length = 65536, batch_number_here = 0) {
   let x = new Float32Array(length);
   let y = new Float32Array(length);
@@ -44,6 +57,17 @@ function make_batch(start = 0, length = 65536, batch_number_here = 0) {
     randoms[i - start] = Math.random();
   }
 
+  // Create an array that looks like 0, 1, 1, ..., 1, 2
+  // and shuffle it
+  function sandwich(n) {
+    const arr = [0, 2, ...Array(Math.max(n - 2, 1)).fill(1)];
+    for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
   function num_to_string(num) {
     return num.toString();
   }
@@ -55,6 +79,7 @@ function make_batch(start = 0, length = 65536, batch_number_here = 0) {
     integers: vectorFromArray(integers),
     batch_id: vectorFromArray(batch_id),
     random: vectorFromArray(randoms),
+    sandwich: vectorFromArray(sandwich(length)),
   });
 }
 


### PR DESCRIPTION
Working solution with tests. Assumes all the tile sorts can be loaded into memory. If not, we need to bring back two heaps
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduce heap sort for tile sorting in Deepscatter with `TileSorter` and `MinHeap`, and add tests for sorting functionality.
> 
>   - **Behavior**:
>     - Introduces `TileSorter` class in `selection.ts` for heap-based sorting of tiles.
>     - Adds `iterator()` method in `SortedDataSelection` to iterate over sorted data using `TileSorter`.
>     - Implements `MinHeap` class in `utilityFunctions.ts` for managing heap operations.
>   - **Tests**:
>     - Adds tests in `dataset.spec.js` for sorting and iterated sorting of selections using the new heap sort mechanism.
>     - Tests cover both normal and reverse iteration over sorted data.
>   - **Misc**:
>     - Minor import adjustments in `selection.ts` and `deepscatter.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fdeepscatter&utm_source=github&utm_medium=referral)<sup> for f1ceb61b6e2cae1ef1f6771948e32d795d7aa3e4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->