### PR TITLE
add flatTree method

### DIFF
--- a/src/Deeptable.ts
+++ b/src/Deeptable.ts
@@ -93,7 +93,9 @@ export class Deeptable {
     resolve?: () => void;
   }> = new Set();
   public selection_history: DS.SelectionRecord[] = [];
-
+  // The flatTree is a representation of known tiles in the quadtree in a flat format
+  // indexed by tile index (`tix` -- see `tixRixQid`).
+  public flatTree: (Tile | undefined | null)[] = [];
   public promise: Promise<void>;
   public root_tile: Tile;
   public manifest?: DS.TileManifest;

--- a/src/tile.ts
+++ b/src/tile.ts
@@ -102,7 +102,7 @@ export class Tile {
       manifest = key;
     }
     this.key = manifest.key;
-    const coords = this.key.split('/').map(parseInt);
+    const coords = this.key.split('/').map((value) => parseInt(value, 10));
     while (coords.length < 3) {
       coords.push(0);
     }

--- a/src/tile.ts
+++ b/src/tile.ts
@@ -24,6 +24,7 @@ export type Rectangle = {
 
 import type { ArrowBuildable, LazyTileManifest, TileManifest } from './types';
 import { isCompleteManifest } from './typing';
+import { tileKey_to_tix, zxyToTix } from './tixrixqid';
 
 export type RecordBatchCache =
   | {
@@ -56,6 +57,7 @@ export class Tile {
   protected _batch?: RecordBatch;
   parent: Tile | null;
   private _children: Array<Tile> = [];
+  private readonly _tix: number;
   public _highest_known_ix?: number;
   public deeptable: Deeptable;
   public _transformations: Record<string, Promise<ArrowBuildable>> = {};
@@ -100,6 +102,13 @@ export class Tile {
       manifest = key;
     }
     this.key = manifest.key;
+    const coords = this.key.split('/').map(parseInt);
+    while (coords.length < 3) {
+      coords.push(0);
+    }
+    const tix = zxyToTix(coords[0], coords[1], coords[2]);
+    this._tix = tix;
+    deeptable.flatTree[tix] = this;
     // if (manifest.min_ix === undefined) {
     //   manifest.min_ix = parent ? parent.max_ix + 1 : 0;
     // }
@@ -171,6 +180,9 @@ export class Tile {
     return existing;
   }
 
+  get tix() {
+    return this._tix;
+  }
   /**
    *
    * @param fields A list of keys to be created if they don't exist.


### PR DESCRIPTION
Adds flat index with tixes to the deeptable for convenience
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `flatTree` method to `Deeptable` for flat tile indexing and update `Tile` to calculate and store `tix`.
> 
>   - **Deeptable**:
>     - Adds `flatTree` array to store tiles in a flat format indexed by `tix`.
>   - **Tile**:
>     - Calculates `tix` using `tileKey_to_tix` and updates `flatTree` in `Deeptable` constructor.
>     - Adds `tix` getter to return `_tix` value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fdeepscatter&utm_source=github&utm_medium=referral)<sup> for 5d8edb9eb43e6aa3be0e1b0487763f659f460135. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->