### PR TITLE
fix tests

### DIFF
--- a/tests/dataset.spec.js
+++ b/tests/dataset.spec.js
@@ -95,8 +95,7 @@ test('Test composition of selections', async () => {
   });
 
   await selectNothing.applyToAllLoadedTiles();
-  const v = selectNothing.get();
-  console.log(v);
+  assert.is(selectNothing.selectionSize, 0);
 });
 
 test('Test sorting of selections', async () => {


### PR DESCRIPTION
Make a broken test not fail
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix test in `dataset.spec.js` to assert empty selection size instead of logging.
> 
>   - **Tests**:
>     - In `dataset.spec.js`, replace `console.log(v)` with `assert.is(selectNothing.selectionSize, 0)` in the 'Test composition of selections' test to ensure the test checks for an empty selection instead of logging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fdeepscatter&utm_source=github&utm_medium=referral)<sup> for 01902c389f43cfae3a961e140ac169fcf7392240. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->