### PR TITLE
better mimic js array in selection getters

### DIFF
--- a/tests/dataset.spec.js
+++ b/tests/dataset.spec.js
@@ -95,6 +95,7 @@ test('Test composition of selections', async () => {
 
   await selectNothing.applyToAllLoadedTiles();
   assert.is(selectNothing.selectionSize, 0);
+  assert.is(selectNothing.get(), undefined);
 });
 
 test('Test sorting of selections', async () => {
@@ -121,6 +122,12 @@ test('Test sorting of selections', async () => {
   const mid = sorted.get(Math.floor(sorted.selectionSize / 2));
   assert.ok(mid.random > 0.45);
   assert.ok(mid.random < 0.55);
+
+  // Check negative offsets
+  const end = sorted.get(-1);
+  const end2 = sorted.get(8191);
+  assert.ok(end.random > 0.99);
+  assert.ok(end.ix === end2.ix);
 });
 
 test('Test iterated sorting of selections', async () => {
@@ -169,14 +176,14 @@ test('Test iterated sorting of selections', async () => {
   const second = sorted.iterator(5);
 
   const numbers = [0, 1, 2, 3, 5, 6, 7, 8, 9, 10];
-  const firstVals = numbers.map(d => first.next().value[sortKey])
-  
+  const firstVals = numbers.map((d) => first.next().value[sortKey]);
+
   for (let i = 0; i < 5; i++) {
     assert.ok(firstVals[5 + i] === second.next().value[sortKey]);
   }
 });
 
-test ('Iterated sorting of empty selection', async() => {
+test('Iterated sorting of empty selection', async () => {
   const dataset = createIntegerDataset();
   await dataset.root_tile.preprocessRootTileInfo();
   const emptySelection = new DataSelection(dataset, {
@@ -207,7 +214,7 @@ test ('Iterated sorting of empty selection', async() => {
     thrown = true;
   }
   assert.ok(thrown);
-})
+});
 
 test('Edge cases for iterated sorting of selections', async () => {
   const dataset = createIntegerDataset();


### PR DESCRIPTION
Changes to the `Selection.get()` and `SortedSelection.get()` methods.

1. Change so that rather than error on out of bounds selection, we return undefined
2. Allow using a negative number so that selection.get(-1) returns the last element in the selection, etc.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `Selection.get()` and `SortedSelection.get()` now return `undefined` for out-of-bounds indices and support negative indices, with tests updated accordingly.
> 
>   - **Behavior**:
>     - `Selection.get()` and `SortedSelection.get()` now return `undefined` for out-of-bounds indices instead of throwing an error.
>     - Support for negative indices added to `Selection.get()` and `SortedSelection.get()`, allowing retrieval from the end of the selection.
>   - **Tests**:
>     - Added test cases in `dataset.spec.js` to verify `undefined` return for out-of-bounds indices and correct behavior for negative indices in `get()` methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fdeepscatter&utm_source=github&utm_medium=referral)<sup> for d88aa776b6d35fc24bc58c0424471460c08c7526. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->