### PR TITLE
refactor buffer storage 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepscatter",
   "type": "module",
-  "version": "3.0.0-next.43",
+  "version": "3.0.0-next.45",
   "description": "Fast, animated zoomable scatterplots scaling to billions of points",
   "files": [
     "dist"

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,11 +11,11 @@ import type {
   Timestamp,
   Utf8,
   Vector,
+  Type,
 } from 'apache-arrow';
 import type { Renderer } from './rendering';
 import type { Deeptable } from './Deeptable';
 import type { ConcreteAesthetic } from './aesthetics/StatefulAesthetic';
-import type { Buffer } from 'regl';
 import type { DataSelection } from './selection';
 import { Scatterplot } from './scatterplot';
 import { ZoomTransform } from 'd3-zoom';
@@ -29,14 +29,19 @@ export type { Renderer, Deeptable, ConcreteAesthetic };
  * can find data on it.
  *
  * Note that the byte_size is *for the buffer*, and that individual elements
- * may take views of it less than the byte_size.
+ * may take views of it less` than the byte_size.
  */
-export type BufferLocation = {
-  buffer: Buffer;
+export interface BufferLocation<T> {
+  buffer: T;
   offset: number;
-  stride: number;
-  byte_size: number; // in bytes;
+  stride?: number;
+  byte_size?: number; // in bytes;
 };
+
+export type WebGPUBufferLocation = BufferLocation<GPUBuffer> & {
+  arrowType?: Type,
+  paddedSize: number;
+} 
 
 export type Newable<T> = { new (...args: unknown[]): T };
 export type PointFunction<T = number> = (p: StructRowProxy) => T;


### PR DESCRIPTION
This takes the memory management class used to hold webGL buffers and breaks it into an abstract type and a webGL specific type so that we can re-use the same code later to hold webGPU memory as well.