### PR TITLE
qid as number, number and cleanup fromArrow

### DIFF
--- a/dev/FourClasses.svelte
+++ b/dev/FourClasses.svelte
@@ -8,8 +8,8 @@
   import SelectPoints from './svelte/SelectPoints.svelte';
   const startSize = 2;
   const prefs = {
-    source_url: '/newtiles',
-    max_points: 10,
+    source_url: '/tiles',
+    max_points: 10000,
     alpha: 35, // Target saturation for the full page.
     zoom_balance: 0.22, // Rate at which points increase size. https://observablehq.com/@bmschmidt/zoom-strategies-for-huge-scatterplots-with-three-js
     point_size: startSize, // Default point size before application of size scaling

--- a/dev/svelte/SelectPoints.svelte
+++ b/dev/svelte/SelectPoints.svelte
@@ -8,8 +8,8 @@
     const selection = await scatterplot.deeptable.select_data({
       name: Math.random().toFixed(8),
       tileFunction: async (tile) => {
-        const b = new Bitmask(tile.manifest.nPoints);
-        for (let i = 0; i < tile.manifest.nPoints; i++) {
+        const b = new Bitmask(tile.metadata.nPoints);
+        for (let i = 0; i < tile.metadata.nPoints; i++) {
           if (Math.random() < 0.001) {
             b.set(i);
           }

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -15,6 +15,7 @@ import type { Deeptable } from './Deeptable';
 import type * as DS from './types';
 import type { Scatterplot } from './scatterplot';
 import { PositionalAesthetic } from './aesthetics/ScaledAesthetic';
+import { Qid } from './tixrixqid';
 type Annotation = {
   x: number;
   y: number;
@@ -181,10 +182,12 @@ export class Zoom {
     this.zoomer = zoomer;
   }
 
-  set_highlit_points(data: StructRowProxy[]) {
+  set_highlit_points(dd: Qid[]) {
     const { x_, y_ } = this.scales();
     const xdim = this.scatterplot.dim('x') as PositionalAesthetic;
     const ydim = this.scatterplot.dim('y') as PositionalAesthetic;
+    
+    const data = this.scatterplot.deeptable.getQids(dd)
     this.scatterplot.highlit_point_change(data, this.scatterplot);
 
     const annotations: Annotation[] = data.map((d) => {
@@ -224,10 +227,6 @@ export class Zoom {
       .on('click', (ev, dd) => {
         this.scatterplot.click_function(dd, this.scatterplot);
       });
-  }
-
-  set_highlit_point(point: StructRowProxy) {
-    this.set_highlit_points([point]);
   }
 
   add_mouseover() {

--- a/src/regl_rendering.ts
+++ b/src/regl_rendering.ts
@@ -33,7 +33,6 @@ import {
   Data,
   Dictionary,
   Struct,
-  StructRowProxy,
   Type,
   Utf8,
   Vector,
@@ -43,6 +42,7 @@ import { StatefulAesthetic } from './aesthetics/StatefulAesthetic';
 import { Filter, Foreground } from './aesthetics/BooleanAesthetic';
 import { ZoomTransform } from 'd3-zoom';
 import { Some, TupleMap, TupleSet } from './utilityFunctions';
+import { Qid } from './tixrixqid';
 // eslint-disable-next-line import/prefer-default-export
 export class ReglRenderer extends Renderer {
   public regl: Regl;
@@ -546,7 +546,7 @@ export class ReglRenderer extends Renderer {
     return v;
   }
 
-  color_pick(x: number, y: number): null | StructRowProxy {
+  color_pick(x: number, y: number): null | Qid {
     if (y === 0) {
       // Not sure why, but this makes things complainy.
       // console.warn('that thing again.');
@@ -561,15 +561,7 @@ export class ReglRenderer extends Renderer {
     if (row_number === -1) {
       return null;
     }
-    for (const tile of this.visible_tiles()) {
-      if (tile.tix === tile_number) {
-        return tile.record_batch.get(row_number);
-      }
-    }
-    return null;
-    //    const p = this.tileSet.findPoint(point_as_int);
-    //    if (p.length === 0) { return; }
-    //    return p[0];
+    return [tile_number, row_number]
   }
 
   color_pick_single(

--- a/src/tile.ts
+++ b/src/tile.ts
@@ -78,7 +78,7 @@ export class Tile {
    * @param key Either the string identifier of the tile,
    * OR a `TileManifest` object including an identifier.   *
    * @param parent The parent tile -- used to navigate through the tree.
-   * @param deeptable The full atlas deeptable of which this tile is a part.
+   * @param deeptable The full deepscatter deeptable of which this tile is a part.
    */
   constructor(key: string, parent: Tile | null, deeptable: Deeptable) {
     // If it's just initiated with a key, build that into a minimal manifest.
@@ -295,16 +295,16 @@ export class Tile {
   }
 
   set metadata(
-    manifest: TileMetadata | (TileMetadata & { extent: Rectangle }),
+    metadata: TileMetadata | (TileMetadata & { extent: Rectangle }),
   ) {
     // Setting the manifest is the thing that spawns children.
-    this.highest_known_ix = manifest.max_ix;
+    this.highest_known_ix = metadata.max_ix;
     this._metadata = {
-      ...manifest,
+      ...metadata,
       extent:
-        typeof manifest.extent === 'string'
-          ? (JSON.parse(manifest.extent) as Rectangle)
-          : manifest.extent,
+        typeof metadata.extent === 'string'
+          ? (JSON.parse(metadata.extent) as Rectangle)
+          : metadata.extent,
     };
   }
 

--- a/src/tixrixqid.ts
+++ b/src/tixrixqid.ts
@@ -8,7 +8,7 @@ import type {
 } from 'apache-arrow';
 
 import type { Tile } from './deepscatter';
-import { Bitmask, DataSelection, Deeptable } from './deepscatter';
+import { DataSelection, Deeptable } from './deepscatter';
 
 // The type below indicates that a Qid is not valid if
 // there are zero rows selected in the tile.

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ import type {
   Timestamp,
   Utf8,
   Vector,
+  TypeMap,
 } from 'apache-arrow';
 import type { Renderer } from './rendering';
 import type { Deeptable } from './Deeptable';
@@ -45,6 +46,9 @@ export type PointFunction<T = number> = (p: StructRowProxy) => T;
  * A proxy class that wraps around tile get calls. Used to avoid
  * putting Nomic login logic in deepscatter while fetching
  * tiles with authentication.
+ * 
+ * An API call type must return Uint8Arrays that represent arrow 
+ * tables of the type produced by quadfeather.
  *
  */
 export interface TileProxy {
@@ -101,7 +105,7 @@ export type DeeptableCreateParams = {
 
   // A manifest listing all the tiles in the deeptable, of the type created by
   // quadfeather v2.0.0 or greater.
-  tileManifest?: Table;
+  tileManifest?: Table<{key: Utf8}>;
 
   // A URL for an arrow file manifest. The schema for this manifest
   // is not yet publically documented: I hope to bundle it into the

--- a/tests/dataset.spec.js
+++ b/tests/dataset.spec.js
@@ -28,7 +28,7 @@ test('Columns can be deleted and replaced', async () => {
 
   dataset.transformations['integers'] = async function (tile) {
     await tile.populateManifest();
-    return new Float32Array(tile.manifest.nPoints);
+    return new Float32Array(tile.metadata.nPoints);
   };
 
   dataset.deleteColumn('integers');


### PR DESCRIPTION
Two related goals in this one.

1. It has turned out to be more useful to refer to points by their quadtree id ("qid"), the tuple of the tile number and row number. This makes mouseover function return that tuple instead, and changes the definition to be [number, number] instead of [number, Some<number>]. Internal Atlas code may have to change to accomodate this.
2. The tile Manifest loading code now works on Arrow tiles as well. We are moving to a world where the existence of a manifest is a hard requirement in deepscatter. I think this is OK.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> This PR updates QID handling to use consistent tuples and enhances manifest loading for Arrow tiles, affecting several core functions and tests.
> 
>   - **Behavior**:
>     - `Qid` is now consistently a tuple `[number, number]` instead of `[number, Some<number>]`.
>     - Mouseover functions return QID tuples.
>     - Manifest loading now supports Arrow tiles, making manifests mandatory.
>   - **Functions**:
>     - `getQids()` in `Deeptable.ts` retrieves `StructRowProxy` for QID tuples.
>     - `color_pick()` in `regl_rendering.ts` returns QID tuples.
>     - `set_highlit_points()` in `interaction.ts` uses QID tuples.
>   - **Misc**:
>     - Update `max_points` and `source_url` in `FourClasses.svelte`.
>     - Replace `manifest` with `metadata` in `SelectPoints.svelte` and `dataset.spec.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nomic-ai%2Fdeepscatter&utm_source=github&utm_medium=referral)<sup> for 62ea24228260cc83542364c02072911d381b243f. You can [customize](https://app.ellipsis.dev/nomic-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->